### PR TITLE
Docs (README): use via.placeholder.com for colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Semantic highlighting and solidity insights for passive security awareness. Most
 * easily differentiate between arithmetics vs. logical operations
 * make **Constructor** and **Fallback** function more prominent
 
-Code fragments passively draw your attention to statements that typically <span style="color:green">*reduce risk* (![#c5f015](https://placehold.it/15/c5f015/000000?text=+))</span> or <span style="color:red">*need your attention* (![#f03c15](https://placehold.it/15/f03c15/000000?text=+))</span>.
+Code fragments passively draw your attention to statements that typically <span style="color:green">*reduce risk* ![#c5f015](https://via.placeholder.com/15/ccff00/000000?text=+)</span> or <span style="color:red">*need your attention* ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+)</span>.
 
 ##### Semantic Highlighting
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Semantic highlighting and solidity insights for passive security awareness. Most
 * easily differentiate between arithmetics vs. logical operations
 * make **Constructor** and **Fallback** function more prominent
 
-Code fragments passively draw your attention to statements that typically <span style="color:green">*reduce risk* ![#c5f015](https://via.placeholder.com/15/ccff00/000000?text=+)</span> or <span style="color:red">*need your attention* ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+)</span>.
+Code fragments passively draw your attention to statements that typically <span style="color:#c5f015">*reduce risk* ![#c5f015](https://via.placeholder.com/15/ccff00/000000?text=+)</span> or <span style="color:#f03c15">*need your attention* ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+)</span>.
 
 ##### Semantic Highlighting
 


### PR DESCRIPTION
## Summary

Closes https://github.com/ConsenSys/vscode-solidity-auditor/issues/92

This uses `via.placeholder.com` for colors in the syntax highlighting section of the README, updating "green" for [`#ccff00`](https://www.colorhexa.com/ccff00), the closest websafe color to [`#c5f015`](https://www.colorhexa.com/c5f015). For consistency, the inline CSS uses the specific hex color code to match rather than the previous strings (`red`, `green`). 

Because both the GitHub.com README and the [VS Code listing](https://marketplace.visualstudio.com/items?itemName=tintinweb.solidity-visual-auditor) rely on this README file, this approach ensures that GitHub can render the color blocks appropriately and VS Code can apply the appropriate color to text.