### PR TITLE
Configurable trailing "arrow" for semantic function argument highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,6 +304,11 @@
                     "default": true,
                     "description": "Whether to enable/disable semantic highlighting for function arguments"
                 },
+                "solidity-va.deco.argumentsSuffix": {
+                    "type": "string",
+                    "default": "⬆",
+                    "description": "custom Suffix/Character that is appended to the decoration when performing semantic highlighting for function arguments"
+                },
                 "solidity-va.deco.warn.reserved": {
                     "type": "boolean",
                     "default": true,

--- a/src/features/deco.js
+++ b/src/features/deco.js
@@ -10,6 +10,8 @@ const vscode = require('vscode');
 const path = require('path');
 const mod_parser = require('solidity-workspace');
 const { getAstValueForExpression } = require('./symbols');
+const settings = require('../settings');
+
 
 const decoStyleRedLine = vscode.window.createTextEditorDecorationType({
     isWholeLine: true,
@@ -309,6 +311,8 @@ function init(context) {
         gutterIconSize: "50%",
     });
 
+    const decoSuffix = settings.extensionConfig().deco.argumentsSuffix;
+
     [...Array(15).keys()].forEach(function (idx) {
         styles["styleArgument" + idx] = vscode.window.createTextEditorDecorationType({
             //cursor: 'crosshair',
@@ -332,7 +336,7 @@ function init(context) {
                 borderColor: "black"
             },
             after: {
-                contentText: "⬆",
+                contentText: decoSuffix || undefined,
                 fontStyle: "normal",
                 color: RGBtoHex(...HSLtoRGB(((6 + idx) * 19) % 255 / 255, 0.85, 0.75)) + "95"
             }


### PR DESCRIPTION
adds configuration option `solidity-va.deco.argumentsSuffix` to control the "arrow" decoration for semantic function highlighting. It can now be removed (empty string) or changed to any other character/string. Default `⬆´

see trailing "arrow" in function argument decoration:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/2865694/166311755-a6fc73b1-5304-4f7d-8b02-8bb6ae98fecc.png">


fixes #100