### PR TITLE
customize semantic highlighting mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Please refer to the extension's contribution section to show an up-to-date list 
 * `Solidity-va.hover` ... Enable or Disable generic onHover information (asm instruction signatures, security notes)
 * `Solidity-va.deco.statevars` ... decorate statevars in code view (golden, green, blue boxes)
 * `Solidity-va.deco.arguments` ... enable/disable or select the mode for semantic highlighting of function arguments. (default: 'enable' = 'color and arrow')
+* `Solidity-va.deco.argumentsMode` ... select the mode for semantic highlighting of function arguments (may require a reload)
+* `Solidity-va.deco.argumentsSuffix` ... a custom Suffix/Symbol that is appended to the decoration when performing semantic highlighting for function arguments 
 * `Solidity-va.outline.enable` ... enable/disable outline and symbolprovider
 * `Solidity-va.outline.decorations` ... decorate functions according to state mutability function visibility
 * `Solidity-va.outline.inheritance.show` ... add inherited functions to outline view

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Please refer to the extension's contribution section to show an up-to-date list 
 * `Solidity-va.parser.parseImports` ... Whether to recursively parse imports or not
 * `Solidity-va.hover` ... Enable or Disable generic onHover information (asm instruction signatures, security notes)
 * `Solidity-va.deco.statevars` ... decorate statevars in code view (golden, green, blue boxes)
-* `Solidity-va.deco.arguments` ... whether to enable/disable semantic highlighting for function arguments
+* `Solidity-va.deco.arguments` ... enable/disable or select the mode for semantic highlighting of function arguments. (default: 'enable' = 'color and arrow')
 * `Solidity-va.outline.enable` ... enable/disable outline and symbolprovider
 * `Solidity-va.outline.decorations` ... decorate functions according to state mutability function visibility
 * `Solidity-va.outline.inheritance.show` ... add inherited functions to outline view

--- a/package.json
+++ b/package.json
@@ -302,12 +302,22 @@
                 "solidity-va.deco.arguments": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether to enable/disable semantic highlighting for function arguments"
+                    "description": "Whether to enable/disable semantic highlighting for function arguments. (May require a reload)."
+                },
+                "solidity-va.deco.argumentsMode": {
+                    "type": "string",
+                    "enum": [
+                        "color and symbol",
+                        "color only",
+                        "symbol only"
+                    ],
+                    "default": "color and symbol",
+                    "description": "Select the mode for semantic highlighting of function arguments. (May require a reload)."
                 },
                 "solidity-va.deco.argumentsSuffix": {
                     "type": "string",
                     "default": "⬆",
-                    "description": "custom Suffix/Character that is appended to the decoration when performing semantic highlighting for function arguments"
+                    "description": "custom Suffix/Symbol that is appended to the decoration when performing semantic highlighting for function arguments"
                 },
                 "solidity-va.deco.warn.reserved": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
                 "solidity-va.deco.argumentsSuffix": {
                     "type": "string",
                     "default": "⬆",
-                    "description": "custom Suffix/Symbol that is appended to the decoration when performing semantic highlighting for function arguments"
+                    "description": "A custom Suffix/Symbol that is appended to the decoration when performing semantic highlighting for function arguments"
                 },
                 "solidity-va.deco.warn.reserved": {
                     "type": "boolean",

--- a/src/extension.js
+++ b/src/extension.js
@@ -353,7 +353,7 @@ function analyzeSourceUnit(cancellationToken, document, editor) {
 
                             //annotate external calls?
                         });
-                        if (settings.extensionConfig().deco.arguments) {
+                        if (settings.extensionConfig().deco.arguments ) {
                             decorations = decorations.concat(mod_decorator.semanticHighlightFunctionParameters(highlightIdentifiers));
                         }
 

--- a/src/features/deco.js
+++ b/src/features/deco.js
@@ -311,7 +311,9 @@ function init(context) {
         gutterIconSize: "50%",
     });
 
-    const decoSuffix = settings.extensionConfig().deco.argumentsSuffix;
+
+    const decoSuffix = settings.extensionConfig().deco.argumentsMode != "color only" ? settings.extensionConfig().deco.argumentsSuffix : undefined;
+    const shouldHighlightArg = settings.extensionConfig().deco.argumentsMode != "symbol only";
 
     [...Array(15).keys()].forEach(function (idx) {
         styles["styleArgument" + idx] = vscode.window.createTextEditorDecorationType({
@@ -320,20 +322,13 @@ function init(context) {
             wholeLine: false,
             light: {
                 // this color will be used in light color themes
-                backgroundColor: RGBtoHex(...HSLtoRGB(((5 + idx) * 19) % 255 / 255, 0.85, 0.75)) + "50"
+                backgroundColor: shouldHighlightArg ? RGBtoHex(...HSLtoRGB(((5 + idx) * 19) % 255 / 255, 0.85, 0.75)) + "50" : undefined
             },
             dark: {
                 // this color will be used in dark color themes
-                backgroundColor: RGBtoHex(...HSLtoRGB(((8 + idx) * 19) % 255 / 255, 0.99, 0.55)) + "30"
+                backgroundColor: shouldHighlightArg ? RGBtoHex(...HSLtoRGB(((8 + idx) * 19) % 255 / 255, 0.99, 0.55)) + "30" : undefined
                 //color: RGBtoHex(...HSLtoRGB(((6+idx)*19)%255/255, 0.85, 0.75))+"95",
                 //textDecoration: "underline" + RGBtoHex(...HSLtoRGB(((6+idx)*19)%255/255, 0.85, 0.75))+"95"
-            },
-            xbefore: {
-                contentText: " " + idx + " ",
-                color: "black",
-                //fontStyle: "italic",
-                backgroundColor: RGBtoHex(...HSLtoRGB(((6 + idx) * 19) % 255 / 255, 0.85, 0.75)) + "95",
-                borderColor: "black"
             },
             after: {
                 contentText: decoSuffix || undefined,


### PR DESCRIPTION
allow to enable/disable semantic function argument highlighting and introduce a config option to control highlighting modes:

* `color and symbol` - default (decorate + "arrow")
* `color only` - only decorate identifiers declared in the function argument scope 
* `symbol only` - only show an "arrow" next to an identifier declared in the function argument scope

<img width="725" alt="image" src="https://user-images.githubusercontent.com/2865694/180291604-f1a3be47-5aaa-41d4-b734-13dfd813d8ff.png">


fixes #105 