### PR TITLE
more consistent highlighting when clicking on items in the cockpit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Note: Don't forget to check out `preferences → Settings → Solidity Visual De
 
 ## v0.1.4
 - fix: incompatibility with vscode update v1.72.0 - Extension "[...] has provided an invalid tree item." - #114
+- new: optionally disable highlighting in the overview ruler - #115
+
+<img width="440" alt="image" src="https://user-images.githubusercontent.com/2865694/194864316-88b89bf4-331d-43b4-bb0a-324cdcee99da.png">
+
+<img width="185" alt="image" src="https://user-images.githubusercontent.com/2865694/194864195-a1449bb3-9c04-43bb-a011-8d2faf8ffb5a.png"> <img width="181" alt="image" src="https://user-images.githubusercontent.com/2865694/194864429-5d8c42d4-e45b-406d-ad66-e207718aced0.png">
+
+- fix: more consistent highlighting when clicking on an item in the cockpit ExternalCalls/PublicStatechanging views - #110
+  - clicking on a function name highlights the first line of the function instead of the full function block in the editor
+  - clicking on an external call/modifier highlights the invocation in the editor
+
 
 ## v0.1.3
 - new: customize semantic highlighting mode #105 #108

--- a/src/features/cockpit.js
+++ b/src/features/cockpit.js
@@ -18,6 +18,13 @@ function elemLocToRange(elem){
     );
 }
 
+function elemLocToFirstLineRange(elem){
+    return new vscode.Range(
+        new vscode.Position(elem.loc.start.line-1, elem.loc.start.column),
+        new vscode.Position(elem.loc.start.line-1, elem.loc.start.column)
+    );
+}
+
 function nodeTypeName(node){
     if(!node.typeName && node.type==="Identifier"){
         return node.name;
@@ -485,7 +492,7 @@ class PublicMethodsViewDataProvider extends BaseDataProvider {
         return Object.keys(this.data)
             .reduce((ret, key) => {
                 let element = this.data[key];
-                let range = new vscode.Range(element._node.loc.start.line, element._node.loc.start.column, element._node.loc.end.line, element._node.loc.end.column);
+                let range = elemLocToRange(element._node)
                 let modifiers = Object.keys(element.modifiers);
                 let item = {
                     resource: element.resource,
@@ -504,14 +511,14 @@ class PublicMethodsViewDataProvider extends BaseDataProvider {
                             //iconPath: 0,
                             command: {
                                 command: 'solidity-va.cockpit.jumpToRange',
-                                arguments: [element.resource, range],
+                                arguments: [element.resource, elemLocToRange(element.modifiers[name])],
                                 title: 'JumpTo'
                             }
                         };
                     }),
                     command: {
                         command: 'solidity-va.cockpit.jumpToRange',
-                        arguments: [element.resource, range],
+                        arguments: [element.resource, elemLocToFirstLineRange(element._node)],
                         title: 'JumpTo'
                     },
                 };
@@ -839,7 +846,7 @@ class ExtCallViewDataProvider extends BaseDataProvider {
                     }),
                     command: {
                         command: 'solidity-va.cockpit.jumpToRange',
-                        arguments: [first.resource,  elemLocToRange(first.parent.function._node)],
+                        arguments: [first.resource,  elemLocToFirstLineRange(first.parent.function._node)],
                         title: 'JumpTo'
                     },
                 };

--- a/src/features/whatsnew/whatsNew.js
+++ b/src/features/whatsnew/whatsNew.js
@@ -39,6 +39,16 @@ The complete changelog can be found [here](https://github.com/ConsenSys/vscode-s
 ## v0.1.4
 
 - fix: incompatibility with vscode update v1.72.0 - Extension "[...] has provided an invalid tree item." - #114
+- new: optionally disable highlighting in the overview ruler - #115
+
+<img width="440" alt="image" src="https://user-images.githubusercontent.com/2865694/194864316-88b89bf4-331d-43b4-bb0a-324cdcee99da.png">
+
+<img width="185" alt="image" src="https://user-images.githubusercontent.com/2865694/194864195-a1449bb3-9c04-43bb-a011-8d2faf8ffb5a.png"> <img width="181" alt="image" src="https://user-images.githubusercontent.com/2865694/194864429-5d8c42d4-e45b-406d-ad66-e207718aced0.png">
+
+- fix: more consistent highlighting when clicking on an item in the cockpit ExternalCalls/PublicStatechanging views - #110
+  - clicking on a function name highlights the first line of the function instead of the full function block in the editor
+  - clicking on an external call/modifier highlights the invocation in the editor
+
 
 ## v0.1.3 - 🧸
 


### PR DESCRIPTION
- fix: more consistent highlighting when clicking on an item in the cockpit ExternalCalls/PublicStatechanging views - fixes #110
  - clicking on a function name highlights the first line of the function instead of the full function block in the editor
  - clicking on an external call/modifier highlights the invocation in the editor
