### PR TITLE
function, event, and custom error signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ And there is more to come 🙌 stay tuned!
 ![vscode-auditor-flaterra](https://user-images.githubusercontent.com/2865694/55907553-5db8d000-5bd7-11e9-8a11-8cef3964e284.gif)
 * list all function signatures (human readable or json format)  
 ![vscode-auditor-funcsigs](https://user-images.githubusercontent.com/2865694/55907153-3f9ea000-5bd6-11e9-8a47-e69a762963e9.gif)
+* list all custom error signatures (human readable or json format)
 * open remix in external browser
 
 Please refer to the extension's contribution section to show an up-to-date list of commands.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ And there is more to come 🙌 stay tuned!
 * list all function signatures (human readable or json format)  
 ![vscode-auditor-funcsigs](https://user-images.githubusercontent.com/2865694/55907153-3f9ea000-5bd6-11e9-8a47-e69a762963e9.gif)
 * list all custom error signatures (human readable or json format)
+* list all event signatures (human readable or json format)
 * open remix in external browser
 
 Please refer to the extension's contribution section to show an up-to-date list of commands.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
         "onCommand:solidity-va.tools.error.signatures.json",
         "onCommand:solidity-va.tools.error.signatures.forWorkspace",
         "onCommand:solidity-va.tools.error.signatures.forWorkspace.json",
+        "onCommand:solidity-va.tools.event.signatures",
+        "onCommand:solidity-va.tools.event.signatures.json",
+        "onCommand:solidity-va.tools.event.signatures.forWorkspace",
+        "onCommand:solidity-va.tools.event.signatures.forWorkspace.json",
         "onCommand:solidity-va.tools.remix.openExternal",
         "onCommand:solidity-va.cockpit.explorer.refresh",
         "onCommand:solidity-va.cockpit.topLevelContracts.refresh",
@@ -268,6 +272,26 @@
                 "category": "Solidity Visual Developer"
             },
             {
+                "command": "solidity-va.tools.event.signatures",
+                "title": "Tools - list event signatures",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.event.signatures.json",
+                "title": "Tools - list event signatures (json)",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.event.signatures.forWorkspace",
+                "title": "Tools - list event signatures for workspace",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.event.signatures.forWorkspace.json",
+                "title": "Tools - list event signatures for workspace (json)",
+                "category": "Solidity Visual Developer"
+            },
+            {
                 "command": "solidity-va.tools.remix.openExternal",
                 "title": "Tools - launch Remix-IDE",
                 "category": "Solidity Visual Developer"
@@ -477,6 +501,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable/Disable codelens 'errorSigs'"
+                },
+                "solidity-va.codelens.eventSigs.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable/Disable codelens 'eventSigs'"
                 },
                 "solidity-va.codelens.uml.enable": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -249,22 +249,22 @@
             },
             {
                 "command": "solidity-va.tools.error.signatures",
-                "title": "Tools - list error signatures",
+                "title": "Tools - list custom error signatures",
                 "category": "Solidity Visual Developer"
             },
             {
                 "command": "solidity-va.tools.error.signatures.json",
-                "title": "Tools - list error signatures (json)",
+                "title": "Tools - list custom error signatures (json)",
                 "category": "Solidity Visual Developer"
             },
             {
                 "command": "solidity-va.tools.error.signatures.forWorkspace",
-                "title": "Tools - list error signatures for workspace",
+                "title": "Tools - list custom error signatures for workspace",
                 "category": "Solidity Visual Developer"
             },
             {
                 "command": "solidity-va.tools.error.signatures.forWorkspace.json",
-                "title": "Tools - list error signatures for workspace (json)",
+                "title": "Tools - list custom error signatures for workspace (json)",
                 "category": "Solidity Visual Developer"
             },
             {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,12 @@
         "onCommand:solidity-va.tools.flattenCandidates",
         "onCommand:solidity-va.tools.function.signatures",
         "onCommand:solidity-va.tools.function.signatures.json",
+        "onCommand:solidity-va.tools.function.signatures.forWorkspace",
         "onCommand:solidity-va.tools.function.signatures.forWorkspace.json",
+        "onCommand:solidity-va.tools.error.signatures",
+        "onCommand:solidity-va.tools.error.signatures.json",
+        "onCommand:solidity-va.tools.error.signatures.forWorkspace",
+        "onCommand:solidity-va.tools.error.signatures.forWorkspace.json",
         "onCommand:solidity-va.tools.remix.openExternal",
         "onCommand:solidity-va.cockpit.explorer.refresh",
         "onCommand:solidity-va.cockpit.topLevelContracts.refresh",
@@ -233,8 +238,33 @@
                 "category": "Solidity Visual Developer"
             },
             {
+                "command": "solidity-va.tools.function.signatures.forWorkspace",
+                "title": "Tools - list function signatures for workspace",
+                "category": "Solidity Visual Developer"
+            },
+            {
                 "command": "solidity-va.tools.function.signatures.forWorkspace.json",
-                "title": "Tools - list function signatures for all solidity files in workspace (json)",
+                "title": "Tools - list function signatures for workspace (json)",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.error.signatures",
+                "title": "Tools - list error signatures",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.error.signatures.json",
+                "title": "Tools - list error signatures (json)",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.error.signatures.forWorkspace",
+                "title": "Tools - list error signatures for workspace",
+                "category": "Solidity Visual Developer"
+            },
+            {
+                "command": "solidity-va.tools.error.signatures.forWorkspace.json",
+                "title": "Tools - list error signatures for workspace (json)",
                 "category": "Solidity Visual Developer"
             },
             {
@@ -442,6 +472,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable/Disable codelens 'funcSigs'"
+                },
+                "solidity-va.codelens.errorSigs.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable/Disable codelens 'errorSigs'"
                 },
                 "solidity-va.codelens.uml.enable": {
                     "type": "boolean",

--- a/src/extension.js
+++ b/src/extension.js
@@ -651,6 +651,15 @@ function onActivate(context) {
 
         context.subscriptions.push(
             vscode.commands.registerCommand(
+                'solidity-va.tools.function.signatureForAstItem',
+                function (item) {
+                    commands.listFunctionSignatureForAstItem(item);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
                 'solidity-va.tools.error.signatures',
                 function (doc, asJson) {
                     commands.listErrorSignatures(doc || vscode.window.activeTextEditor.document, asJson);
@@ -687,6 +696,15 @@ function onActivate(context) {
 
         context.subscriptions.push(
             vscode.commands.registerCommand(
+                'solidity-va.tools.error.signatureForAstItem',
+                function (item) {
+                    commands.listErrorSignatureForAstItem(item);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
                 'solidity-va.tools.event.signatures',
                 function (doc, asJson) {
                     commands.listEventSignatures(doc || vscode.window.activeTextEditor.document, asJson);
@@ -717,15 +735,6 @@ function onActivate(context) {
                 'solidity-va.tools.event.signatures.forWorkspace.json',
                 function (doc) {
                     commands.listEventSignaturesForWorkspace(true);
-                }
-            )
-        );
-
-        context.subscriptions.push(
-            vscode.commands.registerCommand(
-                'solidity-va.tools.function.signatureForAstItem',
-                function (item) {
-                    commands.listFunctionSignatureForAstItem(item);
                 }
             )
         );

--- a/src/extension.js
+++ b/src/extension.js
@@ -633,9 +633,54 @@ function onActivate(context) {
 
         context.subscriptions.push(
             vscode.commands.registerCommand(
+                'solidity-va.tools.function.signatures.forWorkspace',
+                function (doc) {
+                    commands.listFunctionSignaturesForWorkspace(false);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
                 'solidity-va.tools.function.signatures.forWorkspace.json',
                 function (doc) {
                     commands.listFunctionSignaturesForWorkspace(true);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.error.signatures',
+                function (doc, asJson) {
+                    commands.listErrorSignatures(doc || vscode.window.activeTextEditor.document, asJson);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.error.signatures.json',
+                function (doc) {
+                    commands.listErrorSignatures(doc || vscode.window.activeTextEditor.document, true);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.error.signatures.forWorkspace',
+                function (doc) {
+                    commands.listErrorSignaturesForWorkspace(false);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.error.signatures.forWorkspace.json',
+                function (doc) {
+                    commands.listErrorSignaturesForWorkspace(true);
                 }
             )
         );

--- a/src/extension.js
+++ b/src/extension.js
@@ -687,6 +687,42 @@ function onActivate(context) {
 
         context.subscriptions.push(
             vscode.commands.registerCommand(
+                'solidity-va.tools.event.signatures',
+                function (doc, asJson) {
+                    commands.listEventSignatures(doc || vscode.window.activeTextEditor.document, asJson);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.event.signatures.json',
+                function (doc) {
+                    commands.listEventSignatures(doc || vscode.window.activeTextEditor.document, true);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.event.signatures.forWorkspace',
+                function (doc) {
+                    commands.listEventSignaturesForWorkspace(false);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                'solidity-va.tools.event.signatures.forWorkspace.json',
+                function (doc) {
+                    commands.listEventSignaturesForWorkspace(true);
+                }
+            )
+        );
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
                 'solidity-va.tools.function.signatureForAstItem',
                 function (item) {
                     commands.listFunctionSignatureForAstItem(item);

--- a/src/features/codelens.js
+++ b/src/features/codelens.js
@@ -239,7 +239,7 @@ class SolidityCodeLensProvider  {
             })
         );
         //exclude constructor (item._node.name == null)
-        config.funcSigs.enable && item._node.name && lenses.push(new vscode.CodeLens(range, {
+        config.funcSigs.enable && item._node.name && ['public', 'external'].includes(item._node.visibility) && lenses.push(new vscode.CodeLens(range, {
             command: 'solidity-va.tools.function.signatureForAstItem',
             title: 'funcSig',
             arguments: [item]

--- a/src/features/codelens.js
+++ b/src/features/codelens.js
@@ -112,6 +112,16 @@ class SolidityCodeLensProvider  {
             )
         );
 
+        config.errorSigs.enable && codeLens.push(
+            new vscode.CodeLens(
+                firstLine, {
+                    command: 'solidity-va.tools.error.signatures',
+                    title: 'errorSigs',
+                    arguments: [document]
+                }
+            )
+        );
+
         let parser = this.g_workspace.sourceUnits[document.uri.fsPath];
         if(!parser) {
             console.warn("[ERR] parser was not ready while adding codelenses. omitting contract specific lenses.");

--- a/src/features/codelens.js
+++ b/src/features/codelens.js
@@ -154,7 +154,7 @@ class SolidityCodeLensProvider  {
         );
         
 
-        let annotateContractTypes = ["contract","library", "abstract"];
+        let annotateContractTypes = ["contract", "library", "abstract"];
         /** all contract decls */
         for(let contractObj of Object.values(parser.contracts)){
             if(token.isCancellationRequested){
@@ -167,6 +167,12 @@ class SolidityCodeLensProvider  {
                 /** all function decls */
                 for(let funcObj of contractObj.functions){
                     codeLens = codeLens.concat(this.onFunctionDecl(document, contractObj.name, funcObj));
+                }
+
+                for(let node of contractObj._node.subNodes){
+                    if (node.type == 'CustomErrorDefinition') {
+                        codeLens = codeLens.concat(this.onCustomErrorDecl(node));
+                    }
                 }
             } else if (contractObj._node.kind == "interface"){
                 // add uml to interface
@@ -236,6 +242,22 @@ class SolidityCodeLensProvider  {
         config.funcSigs.enable && item._node.name && lenses.push(new vscode.CodeLens(range, {
             command: 'solidity-va.tools.function.signatureForAstItem',
             title: 'funcSig',
+            arguments: [item]
+            })
+        );
+
+        return lenses;
+    }
+
+    onCustomErrorDecl(item) {
+        let lenses = [];
+        let range = elemLocToRange(item);
+
+        let config = settings.extensionConfig().codelens;
+
+        config.errorSigs.enable && lenses.push(new vscode.CodeLens(range, {
+            command: 'solidity-va.tools.error.signatureForAstItem',
+            title: 'errorSig',
             arguments: [item]
             })
         );

--- a/src/features/codelens.js
+++ b/src/features/codelens.js
@@ -122,6 +122,16 @@ class SolidityCodeLensProvider  {
             )
         );
 
+        config.eventSigs.enable && codeLens.push(
+            new vscode.CodeLens(
+                firstLine, {
+                    command: 'solidity-va.tools.event.signatures',
+                    title: 'eventSigs',
+                    arguments: [document]
+                }
+            )
+        );
+
         let parser = this.g_workspace.sourceUnits[document.uri.fsPath];
         if(!parser) {
             console.warn("[ERR] parser was not ready while adding codelenses. omitting contract specific lenses.");

--- a/src/features/commands.js
+++ b/src/features/commands.js
@@ -537,7 +537,7 @@ ${topLevelContractsText}`;
 
     async listFunctionSignatureForAstItem(item, asJson) {
         let sighashes = mod_utils.functionSignatureFromAstNode(item);
-        this._showSignatures({ AST: {sighashes, collisions: [] } }, 'AST Function', asJson);
+        this._showSignatures({ '': {sighashes, collisions: [] } }, 'Function', asJson);
     }
 
     async listErrorSignatures(document, asJson) {
@@ -548,6 +548,11 @@ ${topLevelContractsText}`;
 
     async listErrorSignaturesForWorkspace(asJson) {
         this._listSignaturesForWorkspace('errorSignatureExtractor', 'Custom Error', asJson);
+    }
+
+    async listErrorSignatureForAstItem(item, asJson) {
+        let sighashes = mod_utils.errorSignatureFromAstNode(item);
+        this._showSignatures({ '': {sighashes, collisions: [] } }, 'Custom Error', asJson);
     }
 
     async listEventSignatures(document, asJson) {

--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -65,7 +65,7 @@ function canonicalizeEvmType(evmArg) {
         const foundings = groups.pop();
         return `${TYPE_ALIASES[foundings.type]}${foundings.tail}`;
     }
-    return evmArg.replace(evmTypeRegex, replacer);
+    return evmArg && evmArg.replace(evmTypeRegex, replacer);
 }
 
 function functionSignatureExtractor(content) {

--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -77,12 +77,12 @@ function errorSignatureExtractor(content) {
 }
 
 function _signatureExtractor(sigType, content) {
-    const errorSigRegex =  new RegExp(`${sigType}\\s+(?<name>[^\\(\\s]+)\\s?\\((?<args>[^\\)]*)\\)`, 'g');
+    const sigRegex =  new RegExp(`${sigType}\\s+(?<name>[^\\(\\s]+)\\s?\\((?<args>[^\\)]*)\\)`, 'g');
     let match;
     let sighashes = {};
     let collisions = [];
     // cleanup newlines, cleanup comment blocks
-    while (match = errorSigRegex.exec(content)) {
+    while (match = sigRegex.exec(content)) {
         let args = match.groups.args.replace(commentRegex(), "").split(",").map(item => canonicalizeEvmType(item.trim().split(" ")[0]));
         let fnsig = `${match.groups.name.trim()}(${args.join(',')})`;
         let sighash = createKeccakHash('keccak256').update(fnsig).digest('hex').toString('hex').slice(0, 8);

--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -119,20 +119,20 @@ function getCanonicalizedArgumentFromAstNode(node){
     } else {
         return null;
     }
-} 
+}
 
-function functionSignatureFromAstNode(item){
+function signatureFromAstNode(item){
+    const node = item._node || item;
+    const funcname = node.name;
 
-    let funcname = item._node.name;
+    const argsItem = node.parameters.type === "ParameterList" ? node.parameters.parameters : node.parameters;
+    const args = argsItem.map(o => canonicalizeEvmType(getCanonicalizedArgumentFromAstNode(o)));
 
-    let argsItem = item._node.parameters.type === "ParameterList" ? item._node.parameters.parameters : item._node.parameters;
-    let args = argsItem.map(o => canonicalizeEvmType(getCanonicalizedArgumentFromAstNode(o)));
+    const sig = `${funcname}(${args.join(',')})`;
+    const sighash = createKeccakHash('keccak256').update(sig).digest('hex').toString('hex').slice(0, 8);
 
-    let fnsig = `${funcname}(${args.join(',')})`;
-    let sighash = createKeccakHash('keccak256').update(fnsig).digest('hex').toString('hex').slice(0, 8);
-
-    let result = {};
-    result[sighash] = fnsig;
+    const result = {};
+    result[sighash] = sig;
     return result;
 }
 
@@ -141,5 +141,6 @@ module.exports = {
     functionSignatureExtractor : functionSignatureExtractor,
     errorSignatureExtractor : errorSignatureExtractor,
     eventSignatureExtractor : eventSignatureExtractor,
-    functionSignatureFromAstNode : functionSignatureFromAstNode
+    functionSignatureFromAstNode : signatureFromAstNode,
+    errorSignatureFromAstNode : signatureFromAstNode,
 };

--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -69,12 +69,20 @@ function canonicalizeEvmType(evmArg) {
 }
 
 function functionSignatureExtractor(content) {
-    const funcSigRegex = /function\s+(?<name>[^\(\s]+)\s?\((?<args>[^\)]*)\)/g;
+    return _signatureExtractor("function", content);
+}
+
+function errorSignatureExtractor(content) {
+    return _signatureExtractor("error", content);
+}
+
+function _signatureExtractor(sigType, content) {
+    const errorSigRegex =  new RegExp(`${sigType}\\s+(?<name>[^\\(\\s]+)\\s?\\((?<args>[^\\)]*)\\)`, 'g');
     let match;
     let sighashes = {};
     let collisions = [];
     // cleanup newlines, cleanup comment blocks
-    while (match = funcSigRegex.exec(content)) {
+    while (match = errorSigRegex.exec(content)) {
         let args = match.groups.args.replace(commentRegex(), "").split(",").map(item => canonicalizeEvmType(item.trim().split(" ")[0]));
         let fnsig = `${match.groups.name.trim()}(${args.join(',')})`;
         let sighash = createKeccakHash('keccak256').update(fnsig).digest('hex').toString('hex').slice(0, 8);
@@ -127,5 +135,6 @@ function functionSignatureFromAstNode(item){
 module.exports = {
     CommentMapperRex : CommentMapperRex,
     functionSignatureExtractor : functionSignatureExtractor,
+    errorSignatureExtractor : errorSignatureExtractor,
     functionSignatureFromAstNode : functionSignatureFromAstNode
 };

--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -76,6 +76,10 @@ function errorSignatureExtractor(content) {
     return _signatureExtractor("error", content);
 }
 
+function eventSignatureExtractor(content) {
+    return _signatureExtractor("event", content);
+}
+
 function _signatureExtractor(sigType, content) {
     const sigRegex =  new RegExp(`${sigType}\\s+(?<name>[^\\(\\s]+)\\s?\\((?<args>[^\\)]*)\\)`, 'g');
     let match;
@@ -136,5 +140,6 @@ module.exports = {
     CommentMapperRex : CommentMapperRex,
     functionSignatureExtractor : functionSignatureExtractor,
     errorSignatureExtractor : errorSignatureExtractor,
+    eventSignatureExtractor : eventSignatureExtractor,
     functionSignatureFromAstNode : functionSignatureFromAstNode
 };


### PR DESCRIPTION
Updates the functions signature hash tools to also work for custom errors and events.

Custom error sighashes can help with debugging when a client receives a custom error hash but does not have the ABI to decode it.

Reformats output to handle multiple files, show sighash by file. Conflicts per file as well.

Use `plaintext` and `json` doc types.

Doesn't open a new document when there are no signatures to report.